### PR TITLE
Documentation updates and fixes

### DIFF
--- a/nanoCAT/recipes/mark_surface.py
+++ b/nanoCAT/recipes/mark_surface.py
@@ -22,7 +22,7 @@ import numpy as np
 
 from scm.plams import Molecule, MoleculeError
 
-from CAT.mol_utils import to_atnum
+from CAT.mol_utils import to_atnum, to_symbol
 from CAT.attachment.distribution import distribute_idx
 from nanoCAT.bde.identify_surface import identify_surface
 
@@ -110,14 +110,14 @@ def replace_surface(mol: Molecule,
     try:
         idx_surface = idx[identify_surface(xyz[idx])]
     except ValueError:
-        raise MoleculeError(f"No atoms with atomic symbol/number {repr(symbol)} available in "
-                            f"{repr(mol.get_formula())}")
+        raise MoleculeError(f"No atoms with atomic symbol {to_symbol(symbol)!r} available in "
+                            f"{mol.get_formula()!r}")
 
     try:
         idx_surface_subset = distribute_idx(xyz, idx_surface, f=f, mode=mode, **kwargs)
     except ValueError:
-        raise MoleculeError("Failed to identify any surface atoms with atomic symbol/number "
-                            f"{repr(symbol)} in {repr(mol.get_formula())}")
+        raise MoleculeError("Failed to identify any surface atoms with atomic symbol "
+                            f"{to_symbol(symbol)!r} in {mol.get_formula()!r}")
     else:
         idx_surface_subset += 1
 

--- a/nanoCAT/recipes/surface_dissociation.py
+++ b/nanoCAT/recipes/surface_dissociation.py
@@ -56,7 +56,7 @@ def dissociate_surface(mol: Molecule,
     --------
     .. code:: python
 
-        >>> from pathlib import path
+        >>> from pathlib import Path
 
         >>> import numpy as np
 
@@ -79,7 +79,8 @@ def dissociate_surface(mol: Molecule,
         # Convert 1- to 0-based indices by substracting 1 from idx
         >>> mol_generator = dissociate_surface(mol, idx-1, symbol='Cl', lig_count=1)
 
-        >>> iterator = zip(row_accumulator(idx), mol_generator)
+        # Note: The indices in idx are (always) be sorted along axis 1
+        >>> iterator = zip(row_accumulator(np.sort(idx, axis=1)), mol_generator)
         >>> for i, mol in iterator:
         ...     mol.write(base_path / f'output{i}.xyz')
 
@@ -214,7 +215,7 @@ def _get_opposite_neighbor(mol: Molecule,
         idx_nn = idx_neighbor[get_nearest_neighbors(xyz2, xyz1, k=k)]
     except IndexError as ex:
         raise ValueError("'k' should be smaller than the total number of surface atoms "
-                         f"(len(idx_neighbor)); observed value: {k}") from ex
+                         f"(len(idx_neighbor)); observed value: {k!r}") from ex
     idx_nn.shape = -1, idx_nn.shape[1] * idx_center.shape[1]
 
     # Find the **n** atoms in **idx_nn** furthest removed from each other
@@ -233,7 +234,7 @@ def _get_surface(mol: Molecule, symbol: str, max_dist: Optional[float] = None) -
         return idx[identify_surface(xyz[idx], max_dist=max_dist)]
     except ValueError as ex:
         raise MoleculeError(f"No atoms with atomic symbol/number {repr(symbol)} available in "
-                            f"{repr(mol.get_formula())}") from ex
+                            f"{mol.get_formula()!r}") from ex
 
 
 def _mark_atoms(mol: Molecule, idx: Iterable[int]) -> None:

--- a/nanoCAT/recipes/surface_dissociation.py
+++ b/nanoCAT/recipes/surface_dissociation.py
@@ -52,6 +52,10 @@ def dissociate_surface(mol: Molecule,
        of **idx**.
     4. Yield :math:`(XY_{n})_{\le m}` molecules constructed from **mol**.
 
+    Note
+    ----
+    The indices supplied in **idx** will, when applicable, be sorted along its last axis.
+
     Examples
     --------
     .. code:: python
@@ -91,7 +95,8 @@ def dissociate_surface(mol: Molecule,
         The input molecule.
 
     idx : array-like, dimensions: :math:`\le 2`
-        An array of indices denoting to-be dissociated atoms (*i.e.* :math:`X`).
+        An array of indices denoting to-be dissociated atoms (*i.e.* :math:`X`);
+        its elements will, if applicable, be sorted along the last axis.
         If a 2D array is provided then all elements along axis 1 will be dissociated
         in a cumulative manner.
         :math:`m` is herein defined as the index along axis 1.


### PR DESCRIPTION
* Typo fixes.
* replaced explicit ``repr()`` calls within f-strings with !r flags.
* Explicitly state in the ``dissociate_surface()`` recipe that the elements of ``idx`` will be sorted.