### PR TITLE
MAINT: Raise a `NotImplementedError` when calculating the bulkiness with <2 anchor atoms

### DIFF
--- a/nanoCAT/mol_bulk.py
+++ b/nanoCAT/mol_bulk.py
@@ -98,10 +98,18 @@ def start_lig_bulkiness(
         core = core_series[ij]
         ligand = lig_series[kl]
 
-        # Calculate V_bulk
-        angle, r_ref = get_core_angle(core)  # type: float, Optional[float]
-        if d != "auto":
+        if len(core.properties.dummies) <= 1 and d == "auto":
+            raise NotImplementedError(
+                "`optional.qd.bulkiness.d = 'auto'` is not allowed for cores with <= 1 anchor atoms"
+            )
+
+        if d == "auto":
+            angle, r_ref = get_core_angle(core)  # type: Any, Optional[float]
+        else:
+            angle = None
             r_ref = d
+
+        # Calculate V_bulk
         r, h = get_lig_radius(ligand)
         V_bulk = get_V(r, h, r_ref, angle, h_lim=h_lim)
         V_list_append(V_bulk)
@@ -184,7 +192,7 @@ def _get_anchor_idx(mol: Molecule) -> int:
 
 
 def get_V(radius_array: np.ndarray, height_array: np.ndarray,
-          d: Optional[float], angle: float, h_lim: Optional[float] = 10.0) -> float:
+          d: Optional[float], angle: Any, h_lim: Optional[float] = 10.0) -> float:
     r"""Calculate the :math:`V_{bulk}`, a ligand- and core-sepcific descriptor of a ligands' bulkiness.
 
     .. math::

--- a/nanoCAT/recipes/bulk.py
+++ b/nanoCAT/recipes/bulk.py
@@ -72,12 +72,12 @@ def bulk_workflow(smiles_list: Iterable[str],
         of all ligads.
         Set to :data:`None` to ignore the lattice spacing.
         Units should be in Angstrom.
-        
+
     height_lim : :class:`float`, optional
         A cutoff above which all atoms are ignored.
         Set to :data:`None` to ignore the height cutoff.
         Units should be in Angstrom.
-        
+
     optimize : :class:`bool`
         Enable or disable the ligand geometry optimization.
 


### PR DESCRIPTION
Raise a `NotImplementedError` if `optional.qd.bulkiness.d = "auto"` and the core has <2 anchor atoms.