### PR TITLE
BUG: Use regex for identifying the to-be concatenated .csv files

### DIFF
--- a/nanoCAT/recipes/fast_sigma.py
+++ b/nanoCAT/recipes/fast_sigma.py
@@ -20,6 +20,7 @@ API
 
 from __future__ import annotations
 
+import re
 import os
 import sys
 import copy
@@ -425,9 +426,12 @@ def run_fast_sigma(  # noqa: E302
 
 def _concatenate_csv(output_dir: Path) -> None:
     """Concatenate all ``{i}.tmp.csv`` files into ``cosmo-rs.csv``."""
-    csv_files = [output_dir / i for i in os.listdir(output_dir) if
-                 os.path.splitext(i)[1] == ".csv" and i != "cosmo-rs.csv"]
+    pattern = "[0-9]+.temp.csv"
+    csv_files = [output_dir / i for i in os.listdir(output_dir) if re.fullmatch(pattern, i)]
     csv_files.sort(key=lambda n: int(n.name.split(".", 1)[0]))
+    if not len(csv_files):
+        raise FileNotFoundError(f"Failed to identify any files with the {pattern!r} pattern "
+                                f"in {str(output_dir)!r} ")
     iterator = iter(csv_files)
 
     # Construct the final .csv file


### PR DESCRIPTION
The pattern finding of regex is highly robust, this minimizing the risk of an unrelated (_i.e._ incompatible) .csv file getting caught.