### PR TITLE
ENH: Preserve the order of elements in the returned dataframe

### DIFF
--- a/nanoCAT/recipes/fast_sigma.py
+++ b/nanoCAT/recipes/fast_sigma.py
@@ -237,7 +237,7 @@ def _inner_loop(
     output_dir: Path,
     ams_dir: None | str,
     solvents: Mapping[str, str],
-) -> pd.DataFrame:
+) -> tuple[int, pd.DataFrame]:
     """Perform the inner loop of :func:`run_fast_sigma`."""
     i, index = args
     if not len(index):
@@ -270,7 +270,7 @@ def _inner_loop(
     df = pd.DataFrame(data, index=index, columns=columns)
     df.sort_index(axis=1, inplace=True)
     df.to_csv(df_filename)
-    return df
+    return i, df
 
 
 @overload
@@ -423,7 +423,9 @@ def run_fast_sigma(  # noqa: E302
             for _ in pool.imap_unordered(func, enumerator):
                 pass
         else:
-            ret = pd.concat([df for df in pool.imap_unordered(func, enumerator)])
+            df_idx_list = [i_df for i_df in pool.imap_unordered(func, enumerator)]
+            df_idx_list.sort(key=lambda i_df: i_df[0])
+            ret = pd.concat(df for _, df in df_idx_list)
     _concatenate_csv(output_dir)
     return ret
 

--- a/tests/test_fast_sigma_recipe.py
+++ b/tests/test_fast_sigma_recipe.py
@@ -13,7 +13,7 @@ from nanoCAT.recipes import run_fast_sigma, get_compkf
 
 PATH = Path("tests") / "test_files"
 
-SMILES = ("CO[H]", "CCO[H]", "CCCO[H]")
+SMILES = ("CCCO[H]", "CCO[H]", "CO[H]")
 SOLVENTS = {
     "water": "$AMSRESOURCES/ADFCRS/Water.coskf",
     "octanol": "$AMSRESOURCES/ADFCRS/1-Octanol.coskf",
@@ -39,20 +39,17 @@ class TestFastSigma:
         tmp_path = PATH / "crs"
         try:
             ref = pd.read_csv(PATH / "cosmo-rs.csv", header=[0, 1], index_col=0)
-            ref.sort_index(axis=0, inplace=True)
             ref.to_csv(PATH / "cosmo-rs.csv")
 
             os.mkdir(tmp_path)
             out = run_fast_sigma(SMILES, SOLVENTS, output_dir=tmp_path, **kwargs)
             if out is not None:
-                out.sort_index(axis=0, inplace=True)
                 np.testing.assert_allclose(out, ref)
 
             csv_file = tmp_path / "cosmo-rs.csv"
             assertion.isfile(csv_file)
 
             df = pd.read_csv(csv_file, header=[0, 1], index_col=0)
-            df.sort_index(axis=0, inplace=True)
             np.testing.assert_allclose(df, ref)
         finally:
             shutil.rmtree(tmp_path)


### PR DESCRIPTION
Ensure that all SMILES in the `fast_sigma` recipe ordered in the same manner as in which they are provided.