### PR TITLE
MAINT: Check the stdout of `$ASMBIN/prop_prediction` for warnings

### DIFF
--- a/nanoCAT/recipes/fast_sigma.py
+++ b/nanoCAT/recipes/fast_sigma.py
@@ -179,8 +179,11 @@ def _run(command: str, smiles: str) -> None | subprocess.CompletedProcess[bytes]
     try:
         status = subprocess.run(command, shell=True, check=True, capture_output=True)
         stderr = status.stderr.decode()
+        stdout = status.stdout.decode()
         if stderr:
             raise RuntimeError(stderr)
+        elif "WARNING" in stdout:
+            raise RuntimeError(stdout.strip("\n").rstrip("\n"))
     except (RuntimeError, subprocess.SubprocessError) as ex:
         warn = RuntimeWarning(f"Failed to compute the sigma profile of {smiles!r}")
         warn.__cause__ = ex


### PR DESCRIPTION
`$ASMBIN/prop_prediction` dumps its warnings in the stdout; not the stderr.

Check the stdout for warnings and promote them to errors when presents.